### PR TITLE
[PR] Override the default GRC configuration to work in Sierra

### DIFF
--- a/grc/grc.bashrc
+++ b/grc/grc.bashrc
@@ -1,0 +1,42 @@
+# This configuration file is copied from the GRC project, which
+# is licensed as GPLv2.
+#
+# See: http://kassiopeia.juls.savba.sk/~garabik/software/grc.html
+# See: https://github.com/garabik/grc
+GRC="$(which grc)"
+if [ "$TERM" != dumb ] && [ -n "$GRC" ]; then
+    alias colourify="$GRC -es --colour=auto"
+    alias blkid='colourify blkid'
+    alias configure='colourify ./configure'
+    alias df='colourify df'
+    alias diff='colourify diff'
+    alias docker='colourify docker'
+    alias docker-machine='colourify docker-machine'
+    alias du='colourify du'
+    alias env='colourify env'
+    alias free='colourify free'
+    alias make='colourify make'
+    alias gcc='colourify gcc'
+    alias g++='colourify g++'
+    alias ip='colourify ip'
+    alias iptables='colourify iptables'
+    alias as='colourify as'
+    alias gas='colourify gas'
+    alias ld='colourify ld'
+    alias ls='colourify ls --color'
+    alias lsblk='colourify lsblk'
+    alias lspci='colourify lspci'
+    alias netstat='colourify netstat'
+    alias ping='colourify ping'
+    alias traceroute='colourify traceroute'
+    alias traceroute6='colourify traceroute6'
+    alias head='colourify head'
+    alias tail='colourify tail'
+    alias dig='colourify dig'
+    alias mount='colourify mount'
+    alias ps='colourify ps'
+    alias mtr='colourify mtr'
+    alias semanage='colourify semanage'
+    alias getsebool='colourify setsebool'
+    alias ifconfig='colourify ifconfig'
+fi

--- a/system/grc.zsh
+++ b/system/grc.zsh
@@ -1,5 +1,11 @@
 # GRC colorizes nifty unix tools all over the place
+#
+# grc.bashrc is normally located in `brew --prefix`/etc/, but a
+# change in the GRC project started using `type -p` instead of
+# `which` to find the location of GRC. This causes errors because
+# of OSX's strange output from `type -p grc`.
+# See: https://github.com/garabik/grc/issues/54
 if (( $+commands[grc] )) && (( $+commands[brew] ))
 then
-  source `brew --prefix`/etc/grc.bashrc
+  source $HOME/dotfiles/grc/grc.bashrc
 fi


### PR DESCRIPTION
This copies the default alias configuration file provided from GRC
as a (possibly) temporary solution. It appears that Sierra has an
issue in what data is returned from `type -p`.

Change from `which` to `type -p` occurred via:
https://github.com/garabik/grc/pull/46

See: https://github.com/garabik/grc/issues/54